### PR TITLE
ci: Fix artifactory upload (use `--flat` layout)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Publish ISO
         run: |
-          jf rt u "output/*.iso" "$DEPLOY_PATH"
+          jf rt upload --flat "output/*.iso" "$DEPLOY_PATH"
 
       - name: Publish Build Info
         run: |


### PR DESCRIPTION
Otherwise, the ISO is published to `output/<artifact-name>`.
