### PR TITLE
feat: Configure all ethernet NICs for DHCP

### DIFF
--- a/src/voraus_debian_iso/data/preseed/preseed.cfg
+++ b/src/voraus_debian_iso/data/preseed/preseed.cfg
@@ -572,7 +572,22 @@ d-i partman/early_command string \
 #
 # The suite names contain the codename and therefore have to be adjusted when DEFAULT_DEBIAN_VERSION is bumped
 # to a Debian release beyond 13 (trixie).
+#
+# Additionally, configure every physical ethernet NIC for DHCP: netcfg only configures the single
+# interface that was used during the installation. Therefore /etc/network/interfaces is reduced to
+# the loopback device and one DHCP stanza per NIC is generated in /etc/network/interfaces.d
+# (rewriting the file also avoids a duplicate stanza for the interface netcfg configured, which
+# ifupdown rejects). Virtual and wireless devices are skipped and "allow-hotplug" is used instead
+# of "auto" so that unplugged NICs do not delay the boot with DHCP timeouts.
 d-i preseed/late_command string \
     in-target sed -i 's/#\?PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config; \
     rm -f /target/etc/apt/sources.list /target/etc/apt/sources.list.d/*.list /target/etc/apt/sources.list.d/*.sources; \
-    printf 'Types: deb\nURIs: http://ftp.de.debian.org/debian\nSuites: trixie trixie-updates\nComponents: main non-free-firmware non-free\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n\nTypes: deb\nURIs: http://security.debian.org/debian-security\nSuites: trixie-security\nComponents: main non-free-firmware non-free\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n' > /target/etc/apt/sources.list.d/debian.sources
+    printf 'Types: deb\nURIs: http://ftp.de.debian.org/debian\nSuites: trixie trixie-updates\nComponents: main non-free-firmware non-free\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n\nTypes: deb\nURIs: http://security.debian.org/debian-security\nSuites: trixie-security\nComponents: main non-free-firmware non-free\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n' > /target/etc/apt/sources.list.d/debian.sources; \
+    printf 'source /etc/network/interfaces.d/*\n\nauto lo\niface lo inet loopback\n' > /target/etc/network/interfaces; \
+    mkdir -p /target/etc/network/interfaces.d; \
+    for n in /sys/class/net/*; do i=$(basename "$n"); \
+      [ -e "$n/device" ] || continue; \
+      [ -d "$n/phy80211" ] && continue; \
+      printf 'allow-hotplug %s\niface %s inet dhcp\n' "$i" "$i" > "/target/etc/network/interfaces.d/$i"; \
+    done; \
+    true

--- a/tests/integration/test_iso.py
+++ b/tests/integration/test_iso.py
@@ -1,11 +1,27 @@
 """Contains all tests for the ISO."""
 
 import sys
+from pathlib import Path
 
 import pytest
 from fabric import Connection
 
 from voraus_debian_iso.methods.cli.cli_start_methods import get_ssh_connection
+
+
+def get_physical_nics(dut: Connection) -> list[str]:
+    """Returns the names of all physical NICs of the DUT.
+
+    Virtual devices (like the loopback device) are excluded because they do not provide a device symlink in sysfs.
+
+    Args:
+        dut: The connection to the device under test.
+
+    Returns:
+        The NIC names, for example ["enp0s3"].
+    """
+    result = dut.run("find /sys/class/net -mindepth 1 -maxdepth 1 -exec test -e {}/device ';' -print")
+    return [Path(path).name for path in result.stdout.split()]
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="Only supported on linux because it requires qemu")
@@ -31,3 +47,22 @@ class TestISO:
     def test_sudo_available(self, dut: Connection) -> None:  # pylint: disable=unused-argument
         root_ssh_connection = next(get_ssh_connection(username="root"))
         assert root_ssh_connection.run("sudo --validate").ok
+
+    def test_networking_service_active(self, dut: Connection) -> None:
+        # A duplicate interface stanza (for example because the interface used during the installation is configured
+        # in /etc/network/interfaces as well as in /etc/network/interfaces.d) makes ifupdown fail.
+        assert dut.run("systemctl is-active networking", warn=True).stdout.strip() == "active"
+
+    def test_interfaces_file_only_configures_loopback(self, dut: Connection) -> None:
+        interfaces = dut.run("cat /etc/network/interfaces").stdout
+        stanzas = [line for line in interfaces.splitlines() if line.startswith("iface")]
+        assert stanzas == ["iface lo inet loopback"]
+
+    def test_all_nics_configured_for_dhcp(self, dut: Connection) -> None:
+        nics = get_physical_nics(dut)
+        assert nics, "The device under test does not provide any physical NIC"
+        for nic in nics:
+            stanza = dut.run(f"cat /etc/network/interfaces.d/{nic}").stdout
+            assert f"allow-hotplug {nic}" in stanza
+            assert f"iface {nic} inet dhcp" in stanza
+            assert "inet " in dut.run(f"ip -4 address show {nic}").stdout


### PR DESCRIPTION
> [!NOTE]
> Depends on #16, which repairs the pipeline. Until that is merged, the checks here fail for reasons unrelated to this change (no `bsdtar` on the runner, so no ISO is built and the integration tests do not run).

## Why

So far only a single NIC ends up configured on an installed system: `netcfg` writes a DHCP stanza for the interface it used during the installation into `/etc/network/interfaces`, and every other ethernet NIC stays unconfigured. Which NIC that is depends on where the network cable happened to be plugged in while installing, so users had to remember that afterwards — plugging into the "wrong" port left the machine without network.

With this change every physical ethernet NIC is configured for DHCP, so it does not matter which port was used during the installation and which one is used later: all of them are ready to connect to a network.

## How

`preseed/late_command` reduces `/etc/network/interfaces` to the loopback device and generates one DHCP stanza per NIC in `/etc/network/interfaces.d`:

* Rewriting `/etc/network/interfaces` also prevents a duplicate stanza for the interface `netcfg` configured, which `ifupdown` rejects (it would make `networking.service` fail on boot).
* Virtual devices (no `device` symlink in sysfs) and wireless devices (`phy80211`) are skipped.
* `allow-hotplug` is used instead of `auto` so that unplugged NICs do not delay the boot with DHCP timeouts.

## Tests

Three integration tests are added:

* `networking.service` is active — the canary for a duplicate interface stanza.
* `/etc/network/interfaces` only configures the loopback device.
* Every physical NIC has a DHCP stanza in `/etc/network/interfaces.d` and an IPv4 address.

## Notes / limitations

* The stanzas are generated at installation time, so a NIC that is added to the machine later is not covered.
* The QEMU test VM only has a single NIC, so the tests verify the mechanism rather than the multi-NIC case. Covering that would require adding NICs to the `install` and `start` commands (with a separate subnet per `-netdev user`, otherwise every NIC gets the same address).
* If several NICs are connected to routed networks, each one pulls its own default route at the same metric, so the egress path is not deterministic. Deterministic egress would need per-interface metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)