### PR TITLE
fix(ci): Install apt packages with apt-get instead of a cache action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,11 @@ jobs:
           fetch-tags: true
 
       - name: Install build dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libarchive-tools xorriso qemu-system-x86
-          version: 1.0
+        # apt-get update is mandatory: the package lists of the runner image are stale, so apt requests .deb
+        # versions that have already been removed from the mirrors, which fails with "404 Not Found".
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libarchive-tools xorriso
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install test dependencies for integration tests (Only supported on Linux)
-        uses: awalsh128/cache-apt-pkgs-action@latest
         if: runner.os == 'Linux'
-        with:
-          packages: qemu-system-x86
-          version: 1.0
+        # apt-get update is mandatory: the package lists of the runner image are stale, so apt requests .deb
+        # versions that have already been removed from the mirrors, which fails with "404 Not Found".
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes qemu-system-x86 qemu-utils
 
       - name: Install tox
         run: python -m pip install --upgrade pip tox==4.23.2 tox-uv~=1.16.0 tox-gh-actions~=3.0

--- a/src/voraus_debian_iso/methods/cli/cli_start_methods.py
+++ b/src/voraus_debian_iso/methods/cli/cli_start_methods.py
@@ -39,7 +39,8 @@ def get_ssh_connection(username: str = "localuser") -> Generator[Connection, Non
             retry=retry_if_exception_type((NoValidConnectionsError, SSHException, TimeoutError)),
             wait=wait_fixed(2),
             stop=stop_after_delay(120),
-            after=after_log(_logger, logging.DEBUG),
+            # tenacity>=9.1 annotates the logger with its own LoggerProtocol, which logging.Logger does not satisfy
+            after=after_log(_logger, logging.DEBUG),  # type: ignore[arg-type]
         )(connection.open)()
         yield connection
 


### PR DESCRIPTION
Two independent reasons why the pipeline is red on `main`. Neither is caused by a code change — both are dependency/environment drift that happened to land between the last green run in January and now.

## 1. apt packages cannot be installed (404)

The `Build ISO` job and the Linux integration tests fail while installing their apt dependencies:

```
E: Failed to fetch .../libarchive-tools_3.7.2-2ubuntu0.7_amd64.deb  404  Not Found
E: Failed to fetch .../gstreamer1.0-plugins-good_1.24.2-1ubuntu1.4_amd64.deb  404  Not Found
```

`bsdtar` is therefore missing and the build aborts with `[Errno 2] No such file or directory: 'bsdtar'`, which also means no ISO artifact and hence no integration tests.

Reasons:

* `cache-apt-pkgs-action` installs against the package lists that ship with the runner image without refreshing them. Those lists are stale, so apt asks for `.deb` versions that have already been removed from the Ubuntu mirrors (`…1ubuntu1.4` has been superseded).
* The action was referenced via `@latest`, which upstream has deprecated and no longer updates: "the `latest` symbol has been deprecated and will no longer be updated. Actions should be pinned to a well known version instead."

Fixed by installing the packages with plain `apt-get` and running `apt-get update` first. Two side effects:

* The build job no longer installs `qemu-system-x86`; building the ISO only needs `bsdtar` and `xorriso`. Nothing in that job starts a VM, and dropping it also removes the `gst-plugins-good` dependency chain that produced part of the 404s.
* The test job requests `qemu-utils` explicitly rather than relying on it being pulled in as a recommended package of `qemu-system-x86`. It provides `qemu-img`, which the `install` step needs.

The removed caching saves little here — `apt-get install` of these packages takes seconds — and in exchange the pipeline no longer depends on an unmaintained third-party action.

## 2. mypy rejects tenacity's after_log

```
src/voraus_debian_iso/methods/cli/cli_start_methods.py:42: error: Argument 1 to "after_log" has incompatible type "Logger"; expected "LoggerProtocol"  [arg-type]
```

`tenacity` >= 9.1 annotates the logger parameter of `after_log()` with its own `LoggerProtocol`, which `logging.Logger` does not structurally satisfy (its `log()` does not accept arbitrary keyword arguments). The call works at runtime, so this is silenced with `# type: ignore[arg-type]` rather than by pinning tenacity. Because `warn_unused_ignores = true` is set, lint will point the ignore out again once tenacity fixes the annotation.

## Verification

`tox run -e lint` passes locally, and on this branch `Build ISO` and the macOS test matrix are green — the previous run failed at the apt step before reaching either.

## Side note

The build log also contains a `404` for `debian-cd/13.3.0/amd64/iso-cd/debian-13.3.0-amd64-netinst.iso`. That one is harmless: 13.3.0 has been superseded by 13.6.0 and moved to `cdimage/archive/`, which the second URL in `_download_iso()` already covers, so the download succeeds. Worth keeping in mind that builds currently depend on that fallback; bumping the default Debian version is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)