### PR TITLE
fix(ci): Assert the Debian major release instead of the point release

### DIFF
--- a/tests/integration/test_iso.py
+++ b/tests/integration/test_iso.py
@@ -12,14 +12,18 @@ from voraus_debian_iso.methods.cli.cli_start_methods import get_ssh_connection
 class TestISO:
     """Contains all ISO tests."""
 
+    # The packages of the installed system come from the Debian mirror and not from the ISO, so its point release
+    # is whatever the mirror serves at installation time. Only the major release (trixie) is therefore asserted.
     def test_debian_version(self, dut: Connection) -> None:
-        assert dut.run("cat /etc/debian_version").stdout.strip() == "13.3"
+        assert dut.run("cat /etc/debian_version").stdout.strip().startswith("13.")
 
     def test_debian_kernel(self, dut: Connection) -> None:
-        assert dut.run("uname -r").stdout.strip() == "6.12.63+deb13-amd64"
+        kernel = dut.run("uname -r").stdout.strip()
+        assert kernel.startswith("6.12.")
+        assert kernel.endswith("+deb13-amd64")
 
     def test_python_version(self, dut: Connection) -> None:
-        assert dut.run("python3 --version").stdout.strip() == "Python 3.13.5"
+        assert dut.run("python3 --version").stdout.strip().startswith("Python 3.13.")
 
     def test_root_ssh_access(self, dut: Connection) -> None:  # pylint: disable=unused-argument
         root_ssh_connection = next(get_ssh_connection(username="root"))


### PR DESCRIPTION
Follow-up to #16. With the apt installation repaired, the integration tests ran again for the first time — and failed, again on drift rather than on a defect:

```
AssertionError: assert '13.6' == '13.3'
AssertionError: assert '6.12.96+deb13-amd64' == '6.12.63+deb13-amd64'
```

## Why

The tests pinned the exact point release of the installed system, its kernel and its Python. Those values are not determined by the ISO though. The preseed installs from `ftp.de.debian.org` and `pkgsel/upgrade` runs a `safe-upgrade`, so the installed system is whatever the mirror serves at installation time — 13.6 by now, while the ISO is still 13.3.0. Every Debian point release therefore breaks these three tests, and pinning `DEFAULT_DEBIAN_VERSION` does not prevent it, because that only pins the installer, not the resulting system.

## How

Assert the major release instead:

* `/etc/debian_version` starts with `13.`
* `uname -r` starts with `6.12.` and ends with `+deb13-amd64`
* `python3 --version` starts with `Python 3.13.`

That still catches a system that is no longer trixie — the case these tests are presumably guarding — without failing on every point release. If you would rather keep the exact pins, the alternative is bumping `DEFAULT_DEBIAN_VERSION` to `13.6.0` plus these three values on every point release.

## Verification

`tox run -e lint` passes. The assertion values come from the failing run on #16, where the installed system reported `13.6`, `6.12.96+deb13-amd64` and (already passing) `Python 3.13.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)