### PR TITLE
feat(debian): Install from a pinned Debian snapshot

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,52 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+
+  // The org baseline (config:best-practices plus the org defaults) is applied by the self-hosted global config,
+  // see https://github.com/vorausrobotik/voraus-iac/blob/main/argocd/apps/renovate/README.md, so it must not be
+  // listed here. Only repository specific configuration belongs in this file.
+
+  // The pinned linting and testing dependencies in pyproject.toml are managed by the project template
+  // ("Do not modify them manually to prevent conflicts during template updates"), so Renovate stays out of them.
+  pep621: {
+    enabled: false,
+  },
+
+  customManagers: [
+    {
+      // The Debian snapshot the system is installed from. Newer timestamps are discovered via the dated tags of
+      // the official debian container image (trixie-YYYYMMDD), because snapshot.debian.org itself does not
+      // publish a machine readable index of its snapshots.
+      customType: 'regex',
+      description: 'Debian snapshot the preseed installs from',
+      managerFilePatterns: ['/^src/voraus_debian_iso/data/preseed/preseed\\.cfg$/'],
+      matchStrings: ['mirror/http/directory string /archive/debian/(?<currentValue>\\d{8})T000000Z'],
+      depNameTemplate: 'debian-snapshot',
+      packageNameTemplate: 'debian',
+      datasourceTemplate: 'docker',
+      extractVersionTemplate: '^trixie-(?<version>\\d{8})$',
+      versioningTemplate: 'loose',
+    },
+    {
+      // The Debian point release whose installer ISO is downloaded. Point releases are published as X.Y.0, so
+      // only the X.Y part is matched, which is what the container image tags provide (13.3, 13.6, ...).
+      customType: 'regex',
+      description: 'Debian point release used for the installer ISO',
+      managerFilePatterns: ['/^src/voraus_debian_iso/constants\\.py$/'],
+      matchStrings: ['DEFAULT_DEBIAN_VERSION = "(?<currentValue>\\d+\\.\\d+)\\.0"'],
+      depNameTemplate: 'debian',
+      datasourceTemplate: 'docker',
+      extractVersionTemplate: '^(?<version>\\d+\\.\\d+)$',
+      versioningTemplate: 'loose',
+    },
+  ],
+
+  packageRules: [
+    {
+      // Both have to be bumped together: the installer ISO and the archive it installs from have to be the same
+      // Debian release. Such a PR fails the integration tests until the versions they assert
+      // (tests/integration/test_iso.py) are updated as well - that failure is the intended signal.
+      matchDepNames: ['debian', 'debian-snapshot'],
+      groupName: 'Debian base',
+    },
+  ],
+}

--- a/src/voraus_debian_iso/data/preseed/preseed.cfg
+++ b/src/voraus_debian_iso/data/preseed/preseed.cfg
@@ -112,9 +112,17 @@ d-i netcfg/wireless_wep string
 # If you select ftp, the mirror/country string does not need to be set.
 # Default value for the mirror protocol: http.
 #d-i mirror/protocol string ftp
+#
+# The installation is performed from a pinned Debian snapshot (https://snapshot.debian.org) instead of a regular
+# mirror, so that the installed package versions are deterministic and the integration tests can assert them
+# explicitly. Renovate proposes newer snapshots, see renovate.json5.
+#
+# snapshot.debian.org resolves any timestamp to the most recent snapshot taken before it, so the timestamp does
+# not have to exist literally. It has to stay in sync with DEFAULT_DEBIAN_VERSION though: 20260121T000000Z
+# serves Debian 13.3, which is what the 13.3.0 installer ISO expects.
 d-i mirror/country string manual
-d-i mirror/http/hostname string ftp.de.debian.org
-d-i mirror/http/directory string /debian
+d-i mirror/http/hostname string snapshot.debian.org
+d-i mirror/http/directory string /archive/debian/20260121T000000Z
 d-i mirror/http/proxy string
 d-i apt-setup/use_mirror boolean true
 d-i apt-setup/cdrom/set-first boolean false
@@ -370,6 +378,12 @@ d-i apt-setup/disable-cdrom-entries boolean true
 # Values shown below are the normal defaults.
 #d-i apt-setup/services-select multiselect security, updates
 #d-i apt-setup/security_host string security.debian.org
+#
+# Neither debian-security nor trixie-updates is pinned to a snapshot, so they must not be used during the
+# installation: a kernel security update published after the snapshot would silently change the installed
+# versions again. An empty value selects none of the services. The installed system gets both back, together
+# with the regular mirrors, in late_command at the end of this file.
+d-i apt-setup/services-select multiselect
 
 # Additional repositories, local[0-9] available
 #d-i apt-setup/local0/repository string \
@@ -550,6 +564,16 @@ d-i partman/early_command string \
 # directly, or use the apt-install and in-target commands to easily install
 # packages and run commands in the target system.
 
-# Allow root login via SSH, otherwise, we cannot configure the system via Ansible
+# Allow root login via SSH, otherwise, we cannot configure the system via Ansible.
+#
+# Furthermore, replace the pinned snapshot repositories with the regular Debian mirrors. The snapshot is only
+# meant to make the installation deterministic; a deployed IPC has to be able to receive updates, so the
+# installed system points at ftp.de.debian.org and security.debian.org afterwards. Every apt configuration
+# written by the installer is removed first, no matter whether it uses the deb822 or the one line format.
+#
+# The suite names contain the codename and therefore have to be adjusted when DEFAULT_DEBIAN_VERSION is bumped
+# to a Debian release beyond 13 (trixie).
 d-i preseed/late_command string \
-    in-target sed -i 's/#\?PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
+    in-target sed -i 's/#\?PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config; \
+    rm -f /target/etc/apt/sources.list /target/etc/apt/sources.list.d/*.list /target/etc/apt/sources.list.d/*.sources; \
+    printf 'Types: deb\nURIs: http://ftp.de.debian.org/debian\nSuites: trixie trixie-updates\nComponents: main non-free-firmware non-free\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n\nTypes: deb\nURIs: http://security.debian.org/debian-security\nSuites: trixie-security\nComponents: main non-free-firmware non-free\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n' > /target/etc/apt/sources.list.d/debian.sources

--- a/src/voraus_debian_iso/data/preseed/preseed.cfg
+++ b/src/voraus_debian_iso/data/preseed/preseed.cfg
@@ -118,8 +118,7 @@ d-i netcfg/wireless_wep string
 # explicitly. Renovate proposes newer snapshots, see renovate.json5.
 #
 # snapshot.debian.org resolves any timestamp to the most recent snapshot taken before it, so the timestamp does
-# not have to exist literally. It has to stay in sync with DEFAULT_DEBIAN_VERSION though: 20260121T000000Z
-# serves Debian 13.3, which is what the 13.3.0 installer ISO expects.
+# not have to exist literally. It has to stay in sync with DEFAULT_DEBIAN_VERSION though.
 d-i mirror/country string manual
 d-i mirror/http/hostname string snapshot.debian.org
 d-i mirror/http/directory string /archive/debian/20260121T000000Z


### PR DESCRIPTION
Replaces #17, which tried to solve the same problem by easing the version assertions. Instead the installed versions are made deterministic, so the assertions can stay exact.

## Why

The ISO only provides the installer — the packages of the installed system come from the mirror, and `pkgsel` runs a `safe-upgrade`. A system installed today is therefore whatever the mirror currently serves, regardless of which ISO version is pinned. As soon as Debian published 13.6, the integration tests failed on their own:

```
AssertionError: assert '13.6' == '13.3'
AssertionError: assert '6.12.96+deb13-amd64' == '6.12.63+deb13-amd64'
```

## How

**Install from a pinned snapshot.** `mirror/http/hostname` + `mirror/http/directory` now point at `snapshot.debian.org/archive/debian/20260121T000000Z`. Snapshot resolves any timestamp to the most recent snapshot taken before it, so the timestamp does not have to exist literally — which also makes it trivially bumpable. That snapshot serves Debian 13.3, matching the 13.3.0 installer ISO.

**No security/updates during the installation.** `apt-setup/services-select` is set empty. Those two are not pinned to a snapshot, and a kernel security update published after the snapshot would silently change the installed kernel and reintroduce exactly the drift this PR removes.

**The snapshot is install-time only.** `late_command` removes the apt configuration written by the installer (both deb822 and one line format) and writes a `debian.sources` pointing at `ftp.de.debian.org` and `security.debian.org`. A deployed IPC therefore still receives updates — the freeze applies to the installation, not to the machine's lifetime.

**No test changes.** The exact assertions are kept as they are; the snapshot was chosen so that they hold.

## Renovate

The org wide self-hosted renovate only picks up repositories that already contain a config file, so `renovate.json5` is added. Per the [org README](https://github.com/vorausrobotik/voraus-iac/blob/main/argocd/apps/renovate/README.md) the baseline comes from the global config and is deliberately not listed. Repository specific parts:

* Custom managers for the snapshot timestamp and for `DEFAULT_DEBIAN_VERSION`, grouped as "Debian base" because installer and archive have to move together. Newer values are discovered via the tags of the official `debian` container image (`trixie-YYYYMMDD` and `13.6`), because neither snapshot.debian.org nor cdimage.debian.org publishes a machine readable index. Only the `X.Y` part of the ISO version is matched, since point releases are published as `X.Y.0`.
* `pep621` is disabled: the pinned linting and testing dependencies in `pyproject.toml` carry the project template's "Do not modify them manually" warning. Say the word if you want them updated anyway.

Two consequences worth knowing:

* **A grouped Debian update PR will fail the integration tests** until the three asserted versions are updated in the same PR. That is the intended signal under "keep exact version assertions", but it does mean those PRs arrive red by design.
* The config uses `managerFilePatterns`, which requires **renovate >= 41** (it replaced `fileMatch`). Validated clean against renovate 44. Your README mentions `abandonments:recommended`, which suggests a recent version — if the self-hosted image is older, the field has to be renamed.

## Verification

Full local run (build, QEMU installation, integration tests) against this branch:

* `6 passed` — including the exact version assertions.
* The installed system reports `13.3`, `6.12.63+deb13-amd64`, `Python 3.13.5`. Against the live mirror the same run produced 13.6 / 6.12.96, so the pin demonstrably takes effect.
* `/etc/apt` contains no `snapshot.debian.org` reference anymore, `/etc/apt/sources.list` is gone and `debian.sources` holds the two expected stanzas.
* `apt-get update` inside the installed system fetches 16.9 MB from `ftp.de.debian.org` and `security.debian.org` without errors.
* The snapshot values were cross checked against the snapshot's own indexes beforehand: `Release` reports `Version: 13.3`, `linux-image-amd64` is `6.12.63-1` (depends on `linux-image-6.12.63+deb13-amd64`) and `python3` is `3.13.5-1`.
* Build plus installation took under 5 minutes locally with KVM. Snapshot throttling was not noticeable, because the base system comes from the ISO and only a few packages are fetched.

## Note

#15 touches the same `late_command` block and will need a trivial rebase once either PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)