### PR TITLE
fix(ci): Group the Debian snapshot update with the point release

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -24,7 +24,11 @@
       packageNameTemplate: 'debian',
       datasourceTemplate: 'docker',
       extractVersionTemplate: '^trixie-(?<version>\\d{8})$',
-      versioningTemplate: 'loose',
+      // The timestamp has to be split into its date components instead of being treated as one number ('loose'
+      // would make 20260121 a major version): Renovate discards updates whose major version increases by more
+      // than maxMajorIncrement (500 by default), so with 'loose' every snapshot more than ~500 days ahead is
+      // silently dropped and a year rollover blocks updates completely.
+      versioningTemplate: 'regex:^(?<major>\\d{4})(?<minor>\\d{2})(?<patch>\\d{2})$',
     },
     {
       // The Debian point release whose installer ISO is downloaded. Point releases are published as X.Y.0, so
@@ -47,6 +51,13 @@
       // (tests/integration/test_iso.py) are updated as well - that failure is the intended signal.
       matchDepNames: ['debian', 'debian-snapshot'],
       groupName: 'Debian base',
+      // Major updates are branched separately by default, which would split the group as soon as one of the two
+      // bumps its major version - a new Debian release for the point release, a new year for the snapshot.
+      separateMajorMinor: false,
+      // Neither value is an image reference that could carry a digest, so the org wide docker:pinDigests must not
+      // apply here. Its pinDigest update ends up in the same branch as the version bump and one of the two is
+      // then discarded ("Ignoring upgrade collision").
+      pinDigests: false,
     },
   ],
 }


### PR DESCRIPTION
Renovate proposed the Debian point release update (13.3 -> 13.6, #22) on its own and never touched the pinned snapshot in preseed.cfg, although both are grouped as "Debian base".

Two things kept the snapshot out of that group, both a consequence of treating the timestamp as a `loose` version, which turns 20260121 into a single eight digit major version:

* Renovate discards updates whose major version increases by more than maxMajorIncrement (500 by default), so the recent snapshots were dropped silently:

    Skipping debian-snapshot@20260713 because major increment 592
    exceeds maxMajorIncrement 500

  A year rollover would eventually have blocked snapshot updates completely.
* The only candidate below that limit (20260610) was classified as a major update, and major updates are branched separately by default, so it ended up in renovate/major-debian-base instead of the group branch.

Parse the timestamp as year.month.day with a regex versioning scheme instead, which keeps the increments small and the update types meaningful, and disable separateMajorMinor for both dependencies so that a future major version of either one (a new Debian release, a new year) stays in the group.

Also disable pinDigests for them. The org wide docker:pinDigests emits an additional pinDigest update for both custom manager dependencies. It lands in the same branch as the version bump, and one of the two is then discarded:

  Ignoring upgrade collision ... previousNewValue: 13.6,
  thisNewValue: 13.3

Neither value is an image reference that could carry a digest, so nothing is lost by opting out.

Verified by running renovate 43 against the working tree (--platform=local --dry-run, with config:best-practices as the global config to emulate the
org baseline): debian 13.3 -> 13.6 and debian-snapshot 20260121 ->
20260713 are both minor updates in the renovate/debian-base branch now, with no collision and no skipped releases.