### PR TITLE
test: Reduce verbosity of the ISO integration test logs

### DIFF
--- a/src/voraus_debian_iso/methods/cli/cli_start_methods.py
+++ b/src/voraus_debian_iso/methods/cli/cli_start_methods.py
@@ -6,7 +6,7 @@ import time
 from pathlib import Path
 from typing import Generator
 
-from fabric import Connection
+from fabric import Config, Connection
 from paramiko.ssh_exception import NoValidConnectionsError, SSHException
 from tenacity import after_log, retry, retry_if_exception_type
 from tenacity.stop import stop_after_delay
@@ -34,6 +34,8 @@ def get_ssh_connection(username: str = "localuser") -> Generator[Connection, Non
         port=2222,
         connect_kwargs={"password": "voraus"},
         connect_timeout=60,
+        # Remote command output is only of interest to the caller, so it is not echoed to the local streams.
+        config=Config(overrides={"run": {"hide": True}}),
     ) as connection:
         retry(
             retry=retry_if_exception_type((NoValidConnectionsError, SSHException, TimeoutError)),


### PR DESCRIPTION
## Why

Fabric echoes the stdout and stderr of every remote command to the local streams by default. The ISO integration tests therefore dumped the contents of `/etc/network/interfaces`, the `interfaces.d` stanzas, the `ip address show` output and the various version strings into the pytest log, which made the test run hard to read:

```
tests/integration/test_iso.py::TestISO::test_interfaces_file_only_configures_loopback source /etc/network/interfaces.d/*

auto lo
iface lo inet loopback
PASSED
```

## What

Hide the remote command output via the connection config in `get_ssh_connection` instead of passing `hide=True` at each of the ten call sites. Configuring it centrally also covers the `root` connections that `test_root_ssh_access` and `test_sudo_available` open themselves.

## Notes

- The assertions are unaffected: `result.stdout` is still captured, only the local echo is suppressed.
- Debuggability on failure is preserved, because a failing command still carries its output tail in the `UnexpectedExit` message.
- The `start` CLI path shares `get_ssh_connection`, but it only opens the connection as a readiness probe and runs no commands, so there is no user-visible change there.
- The remaining log noise (`Connected (version 2.0, ...)`, `Authentication (password) successful!`) comes from paramiko's `INFO` logging rather than from `run`, and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)