### PR TITLE
docs(ci): Explain why pinDigests breaks the Debian snapshot updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -55,8 +55,11 @@
       // bumps its major version - a new Debian release for the point release, a new year for the snapshot.
       separateMajorMinor: false,
       // Neither value is an image reference that could carry a digest, so the org wide docker:pinDigests must not
-      // apply here. Its pinDigest update ends up in the same branch as the version bump and one of the two is
-      // then discarded ("Ignoring upgrade collision").
+      // apply here. It makes Renovate resolve the digest of the extracted version, which for the snapshot is not
+      // a tag at all (20260713 instead of trixie-20260713), and every update whose digest lookup fails is
+      // discarded - the snapshot would get no update whatsoever. For the point release the version happens to be
+      // a valid tag, so there it only adds a pinDigest update that collides with the version bump in the shared
+      // branch ("Ignoring upgrade collision").
       pinDigests: false,
     },
   ],


### PR DESCRIPTION
Follow-up to #29, which fixed the grouping of the Debian point release and the
pinned snapshot but left the reasoning in `renovate.json5` incomplete.

The comment on `pinDigests: false` only mentioned the upgrade collision, which
is the harmless half of the problem. The relevant part is that `pinDigests`
makes Renovate resolve a digest for the *extracted* version, which for the
snapshot dependency is not a tag at all (`20260713` instead of
`trixie-20260713`); the lookup fails and Renovate then discards every update of
that dependency, so the snapshot would get no update whatsoever. Spell that out
so the next reader does not drop the option as redundant.

The diff also contains a string quoting change (single to double quotes)
applied by the editor's formatter. The repository has no formatter config for
`renovate.json5`, so this is noise - say the word and I will strip it and keep
the PR to the commentary alone.
